### PR TITLE
Fix Create Post Channel Selector Clickability

### DIFF
--- a/views/CreatePost/CreatePost.jsx
+++ b/views/CreatePost/CreatePost.jsx
@@ -75,7 +75,7 @@ export default class CreatePost extends React.Component {
     .catch(err => console.error(err));
   }
 
-  
+
   async componentDidMount() {
     const { navigation } = this.props;
     navigation.setParams({
@@ -133,18 +133,18 @@ export default class CreatePost extends React.Component {
     if(data){
       this.updatePost({
         ...data,
-        content: resourceText, 
-        image: image, 
+        content: resourceText,
+        image: image,
         poll: isPoll ? pollData : null
       })
     }else{
       this.addPost({
-        content: resourceText, 
-        image: image, 
+        content: resourceText,
+        image: image,
         poll: isPoll ? pollData : null
       })
     }
-    
+
   }
 
   addPost = (data) => {
@@ -375,6 +375,7 @@ export default class CreatePost extends React.Component {
                 this.state.channels || []
               }
               onValueChange={this.updateChannel}
+              useNativeAndroidPickerStyle={false}
               style={{ //uses inputAndroid and inputiOS style from the stylesheet
                 ...styles,
                 iconContainer: {
@@ -397,7 +398,7 @@ export default class CreatePost extends React.Component {
               rowSpan={3}
             />
           </View>
-          
+
           <View style={styles.ToolbarView}>
             <Toolbar
               pickImage = {this.pickImage}
@@ -409,7 +410,7 @@ export default class CreatePost extends React.Component {
             />
           </View>
           <View style={styles.mediaPreviewView}>
-            <MediaPreview 
+            <MediaPreview
               image={this.state.image}
               poll={this.state.pollData}
               isPoll={this.state.isPoll}


### PR DESCRIPTION
On Android, the channel selector can only be clicked exactly on the line of text, which is difficult for people with large fingers. Fix by setting useNativeAndroidPickerStyle option to false in order to use same rendering on Android as on iOS (a clickable textbox instead of a Picker).